### PR TITLE
fix tuple order of useTransition in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import ReactDOM from 'react-dom';
 import { createFetchStore } from 'react-suspense-fetch';
 
 const DisplayData = ({ result, update }) => {
-  const [startTransition, isPending] = useTransition();
+  const [isPending, startTransition] = useTransition();
   const onClick = () => {
     startTransition(() => {
       update('2');


### PR DESCRIPTION
Experimental builds have flipped the tuple order of useTransition.
Return signature is now [isPending: boolean, startTransition: function]

Relevant commit here:
facebook/react@a632f7d