### PR TITLE
add get options to explicitly force prefetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- add get options to explicitly force prefetch #44
 
 ## [0.5.0] - 2022-05-19
 ### Added

--- a/examples/04_auth/src/UserData.tsx
+++ b/examples/04_auth/src/UserData.tsx
@@ -19,7 +19,9 @@ const userDataStore = createFetchStore(fetchUserDataFunc);
 const UserData = () => {
   const [authState] = useAuthContext();
   if (!authState) throw new Error('no authState');
-  const result = userDataStore.get(authState.getToken());
+  const token = authState.getToken();
+  userDataStore.prefetch(token); // unavoidable waterfalls?
+  const result = userDataStore.get(token);
   return (
     <ul>
       {result.data.map((item) => (

--- a/examples/05_todolist/src/NewItem.tsx
+++ b/examples/05_todolist/src/NewItem.tsx
@@ -17,6 +17,7 @@ const NewItem = ({ setItems }: Props) => {
   const onClick = () => {
     if (!name) return;
     startTransition(() => {
+      createTodoStore.prefetch(name);
       setItems((prev) => [...prev, createTodoStore.get(name)]);
       setName('');
     });


### PR DESCRIPTION
We should require `prefetch` before `get`.
It now throws if `prefecth` is not called in advance.
For an escape hatch, it has an option to work around.